### PR TITLE
Dashboard Entity Page load issue fix

### DIFF
--- a/assets/js/Ioda/components/modal/RawSignalsModal.js
+++ b/assets/js/Ioda/components/modal/RawSignalsModal.js
@@ -412,7 +412,6 @@ class RawSignalsModal extends PureComponent {
                                                     data={this.props.regionalSignalsTableSummaryDataProcessed}
                                                     totalCount={this.props.regionalSignalsTableSummaryDataProcessed.length}
                                                     toggleEntityVisibilityInHtsViz={event => this.props.toggleEntityVisibilityInHtsViz(event, "region")}
-                                                    handleEntityClick={(entityType, entityCode) => this.props.handleEntityClick(entityType, entityCode)}
                                                     handleCheckboxEventLoading={(item) => this.props.handleCheckboxEventLoading(item)}
                                                 />
                                                 : <Loading/>
@@ -423,7 +422,6 @@ class RawSignalsModal extends PureComponent {
                                                     totalCount={this.props.asnSignalsTableTotalCount}
                                                     entityType={this.props.entityType === "asn" ? "country" : "asn"}
                                                     toggleEntityVisibilityInHtsViz={event => this.props.toggleEntityVisibilityInHtsViz(event, "asn")}
-                                                    handleEntityClick={(entityType, entityCode) => this.props.handleEntityClick(entityType, entityCode)}
                                                     handleCheckboxEventLoading={(item) => this.props.handleCheckboxEventLoading(item)}
                                                 /> : <Loading/>
                                         }

--- a/assets/js/Ioda/data/ActionEntities.js
+++ b/assets/js/Ioda/data/ActionEntities.js
@@ -122,14 +122,9 @@ const buildEntityMetadataConfig = (entityType, entityCode) => {
     }
 };
 
-export const getEntityMetadata = (dispatch, entityType, entityCode) => {
+export const getEntityMetadata = ( entityType, entityCode) => {
     let config = buildEntityMetadataConfig(entityType, entityCode);
-    fetchData(config).then(data => {
-        dispatch({
-            type: ENTITY_METADATA,
-            payload: data.data.data,
-        })
-    });
+    return fetchData(config).then(data => data.data.data);
 }
 
 const summaryDataForSignalsTableConfig = (entityType, relatedToEntityType, relatedToEntityCode) => {

--- a/assets/js/Ioda/data/ActionTopo.js
+++ b/assets/js/Ioda/data/ActionTopo.js
@@ -59,14 +59,12 @@ PUBLIC ACTION FUNCTIONS
  * @param dispatch
  * @param entityType
  */
-export const getTopoAction = (dispatch, entityType) => {
+export const getTopoAction = (entityType) => {
     let config = buildTopoConfig(entityType);
-    fetchData(config).then(data => {
-        dispatch({
-            type: GET_TOPO_DATA,
-            subtype: entityType,
-            payload: data.data.data,
-        })
+    return fetchData(config).then(data => {
+        return  {
+            [entityType]: data.data.data
+        }
     });
 }
 

--- a/assets/js/Ioda/pages/entity/Entity.js
+++ b/assets/js/Ioda/pages/entity/Entity.js
@@ -110,6 +110,7 @@ class Entity extends Component {
             parentEntityName: "",
             parentEntityCode: "",
             displayTimeRangeError: false,
+            entityMetadata: {},
             // Data Sources Available
             dataSources: null,
             // Control Panel
@@ -213,11 +214,11 @@ class Entity extends Component {
         this.handleTimeFrame = this.handleTimeFrame.bind(this);
         this.toggleModal = this.toggleModal.bind(this);
         this.handleEntityShapeClick = this.handleEntityShapeClick.bind(this);
-        this.handleEntityClick = this.handleEntityClick.bind(this);
         this.handleCheckboxEventLoading = this.handleCheckboxEventLoading.bind(this);
         this.toggleXyChartModal = this.toggleXyChartModal.bind(this);
         this.changeXyChartNormalization = this.changeXyChartNormalization.bind(this);
         this.handleDisplayAlertBands = this.handleDisplayAlertBands.bind(this);
+        this.updateEntityMetaData = this.updateEntityMetaData.bind(this);
         this.initialTableLimit = 300;
         this.initialHtsLimit = 100;
         this.maxHtsLimit = 150;
@@ -225,6 +226,25 @@ class Entity extends Component {
             window.location.reload();
           });
     }
+
+    updateEntityMetaData(entityName, entityCode) {
+        getEntityMetadata(entityName,entityCode)
+        .then(data => 
+            this.setState({
+                entityMetadata: data,
+                entityName: data[0]["name"],
+                parentEntityName: data[0]["attrs"]["country_name"] ? data[0]["attrs"]["country_name"] : this.state.parentEntityName,
+                parentEntityCode: data[0]["attrs"]["country_code"] ? data[0]["attrs"]["country_code"] : this.state.parentEntityCode
+            }, () => {
+                // Get Topo Data for relatedTo Map
+                // ToDo: update parameter to base value off of url entity type
+                this.getDataTopo("region");
+                this.getDataRelatedToMapSummary("region");
+                this.getDataRelatedToTableSummary("asn");
+            }
+                ))
+    }
+
     componentDidMount() {
         // Monitor screen width
         window.addEventListener("resize", this.resize.bind(this));
@@ -252,7 +272,7 @@ class Entity extends Component {
                         this.props.searchAlertsAction(this.state.from, this.state.until, window.location.pathname.split("/")[1], window.location.pathname.split("/")[2], null, null, null);
                         this.props.getSignalsAction(window.location.pathname.split("/")[1], window.location.pathname.split("/")[2], this.state.from, this.state.until, null, 3000);
                         // Get entity name from code provided in url
-                        this.props.getEntityMetadataAction(window.location.pathname.split("/")[1], window.location.pathname.split("/")[2]);
+                        this.updateEntityMetaData(window.location.pathname.split("/")[1], window.location.pathname.split("/")[2]);
                     }
                 });
             } else {
@@ -270,7 +290,7 @@ class Entity extends Component {
                     this.props.searchAlertsAction(this.state.from, this.state.until, window.location.pathname.split("/")[1], window.location.pathname.split("/")[2], null, null, null);
                     this.props.getSignalsAction(window.location.pathname.split("/")[1], window.location.pathname.split("/")[2], this.state.from, this.state.until, null, 3000);
                     // Get entity name from code provided in url
-                    this.props.getEntityMetadataAction(window.location.pathname.split("/")[1], window.location.pathname.split("/")[2]);
+                    this.updateEntityMetaData(window.location.pathname.split("/")[1], window.location.pathname.split("/")[2]);
                 }
             });
         }
@@ -289,22 +309,6 @@ class Entity extends Component {
             });
         }
 
-        // After API call for getting entity name from url
-        if (this.props.entityMetadata !== prevProps.entityMetadata) {
-            this.setState({
-                entityName: this.props.entityMetadata[0]["name"],
-                parentEntityName: this.props.entityMetadata[0]["attrs"]["country_name"] ? this.props.entityMetadata[0]["attrs"]["country_name"] : this.state.parentEntityName,
-                parentEntityCode: this.props.entityMetadata[0]["attrs"]["country_code"] ? this.props.entityMetadata[0]["attrs"]["country_code"] : this.state.parentEntityCode
-            }, () => {
-                // Get Topo Data for relatedTo Map
-                // ToDo: update parameter to base value off of url entity type
-                // if (window.location.pathname.split("/")[1] === 'country' || window.location.pathname.split("/")[1] === 'region') {
-                this.getDataTopo("region");
-                this.getDataRelatedToMapSummary("region");
-                this.getDataRelatedToTableSummary("asn");
-                // }
-            });
-        }
 
         // After API call for suggested search results completes, update suggestedSearchResults state with fresh data
         if (this.props.suggestedSearchResults !== prevProps.suggestedSearchResults) {
@@ -342,13 +346,6 @@ class Entity extends Component {
             });
         }
 
-        // After API call for topographic data completes, update topoData state with fresh data
-        if (this.props.topoData !== prevProps.topoData) {
-            let topoObjects = topojson.feature(this.props.topoData.region.topology, this.props.topoData.region.topology.objects["ne_10m_admin_1.regions.v3.0.0"]);
-            this.setState({
-                topoData: topoObjects
-            }, this.getMapScores);
-        }
 
         // After API call for outage summary data completes, pass summary data to map function for data merging
         if (this.props.relatedToMapSummary !== prevProps.relatedToMapSummary) {
@@ -574,165 +571,6 @@ class Entity extends Component {
         }
     }
 
-// Global reset State function, called whenever a link that's destination also uses the entity page template is used
-// - an entity name is clicked from the summary/signals table
-// - an entity name is clicked/hit ENTER from the searchbar drop down
-// - the time range input is updated with new values
-// - an entity is clicked on from the map
-    handleStateReset(resetType, range, entityType, entityCode) {
-        switch (resetType) {
-            case "newTimeFrame":
-                this.setState({
-                    from: range[0],
-                    until: range[1],
-                    displayTimeRangeError: false,
-                    // XY Plot Time Series states
-                    xyDataOptions: null,
-                    tsDataRaw: null,
-                    tsDataNormalized: true,
-                    tsDataDisplayOutageBands: true,
-                    tsDataLegendRangeFrom: range[0],
-                    tsDataLegendRangeUntil: range[1],
-                    // Search Bar
-                    suggestedSearchResults: null,
-                    searchTerm: "",
-                    lastFetched: 0,
-                    // Event/Table Data
-                    currentTable: 'alert',
-                    eventDataRaw: null,
-                    eventDataProcessed: [],
-                    alertDataRaw: null,
-                    alertDataProcessed: [],
-                    // relatedTo entity Map
-                    topoScores: null,
-                    summaryDataMapRaw: null,
-                    bounds: null,
-                    // relatedTo entity Table
-                    relatedToTableApiPageNumber: 0,
-                    relatedToTableSummary: null,
-                    relatedToTableSummaryProcessed: null,
-                    relatedToTablePageNumber: 0,
-                    // RawSignalsModal window display status
-                    showMapModal: false,
-                    showTableModal: false,
-                    // Signals RawSignalsModal Table on Map Panel
-                    regionalSignalsTableSummaryData: [],
-                    regionalSignalsTableSummaryDataProcessed: [],
-                    regionalSignalsTableTotalCount: 0,
-                    regionalSignalsTableEntitiesChecked: 0,
-                    // Signals RawSignalsModal Table on Table Panel
-                    asnSignalsTableSummaryData: [],
-                    asnSignalsTableSummaryDataProcessed: [],
-                    asnSignalsTableTotalCount: 0,
-                    asnSignalsTableEntitiesChecked: 0,
-                    // Stacked Horizon Visual on Region Map Panel
-                    rawRegionalSignalsRawBgp: [],
-                    rawRegionalSignalsRawPingSlash24: [],
-                    rawRegionalSignalsRawUcsdNt: [],
-                    rawRegionalSignalsRawMeritNt: [],
-                    rawRegionalSignalsProcessedBgp: null,
-                    rawRegionalSignalsProcessedPingSlash24: null,
-                    rawRegionalSignalsProcessedUcsdNt: null,
-                    rawRegionalSignalsProcessedMeritNt: null,
-                    rawRegionalSignalsLoaded: false,
-                    rawRegionalSignalsLoadAllButtonClicked: false,
-                    // Stacked Horizon Visual on ASN Table Panel
-                    rawAsnSignalsRawBgp: [],
-                    rawAsnSignalsRawPingSlash24: [],
-                    rawAsnSignalsRawUcsdNt: [],
-                    rawAsnSignalsRawMeritNt: [],
-                    rawAsnSignalsProcessedBgp: null,
-                    rawAsnSignalsProcessedPingSlash24: null,
-                    rawAsnSignalsProcessedUcsdNt: null,
-                    rawAsnSignalsProcessedMeritNt: null,
-                    rawAsnSignalsLoaded: false,
-                    rawAsnSignalsLoadAllButtonClicked: false
-                }, () => {
-                    // Get topo and outage data to repopulate map and table
-                    this.props.searchEventsAction(this.state.from, this.state.until, this.state.entityType, this.state.entityCode);
-                    this.props.searchAlertsAction(this.state.from, this.state.until, this.state.entityType, this.state.entityCode, null, null, null);
-                    this.props.getSignalsAction( this.state.entityType, this.state.entityCode, this.state.from, this.state.until, null, null);
-                    this.getDataTopo("region");
-                    this.getDataRelatedToMapSummary("region");
-                    this.getDataRelatedToTableSummary("asn");
-                });
-                break;
-            case "newEntity":
-                this.setState({
-                    mounted: false,
-                    entityType: entityType,
-                    entityCode: entityCode,
-                    entityName: "",
-                    parentEntityName: "",
-                    parentEntityCode: "",
-                    // Search Bar
-                    suggestedSearchResults: null,
-                    searchTerm: "",
-                    lastFetched: 0,
-                    // XY Plot Time Series states
-                    xyDataOptions: null,
-                    tsDataRaw: null,
-                    tsDataNormalized: true,
-                    tsDataDisplayOutageBands: true,
-                    // Event/Table Data
-                    currentTable: 'alert',
-                    eventDataRaw: null,
-                    eventDataProcessed: [],
-                    alertDataRaw: null,
-                    alertDataProcessed: [],
-                    // relatedTo entity Map
-                    summaryDataMapRaw: null,
-                    topoScores: null,
-                    bounds: null,
-                    // relatedTo entity Table
-                    relatedToTableApiPageNumber: 0,
-                    relatedToTableSummary: null,
-                    relatedToTableSummaryProcessed: null,
-                    relatedToTablePageNumber: 0,
-                    // RawSignalsModal window display status
-                    showMapModal: false,
-                    showTableModal: false,
-                    // Signals RawSignalsModal Table on Map Panel
-                    regionalSignalsTableSummaryData: [],
-                    regionalSignalsTableSummaryDataProcessed: [],
-                    regionalSignalsTableTotalCount: 0,
-                    regionalSignalsTableEntitiesChecked: 0,
-                    // Signals RawSignalsModal Table on Table Panel
-                    asnSignalsTableSummaryData: [],
-                    asnSignalsTableSummaryDataProcessed: [],
-                    asnSignalsTableTotalCount: 0,
-                    asnSignalsTableEntitiesChecked: 0,
-                    // Stacked Horizon Visual on Region Map Panel
-                    rawRegionalSignalsRawBgp: [],
-                    rawRegionalSignalsRawPingSlash24: [],
-                    rawRegionalSignalsRawUcsdNt: [],
-                    rawRegionalSignalsRawMeritNt: [],
-                    rawRegionalSignalsProcessedBgp: null,
-                    rawRegionalSignalsProcessedPingSlash24: null,
-                    rawRegionalSignalsProcessedUcsdNt: null,
-                    rawRegionalSignalsProcessedMeritNt: null,
-                    rawRegionalSignalsLoaded: false,
-                    rawRegionalSignalsLoadAllButtonClicked: false,
-                    regionalRawSignalsLoadAllButtonClicked: false,
-                    // Stacked Horizon Visual on ASN Table Panel
-                    rawAsnSignalsRawBgp: [],
-                    rawAsnSignalsRawPingSlash24: [],
-                    rawAsnSignalsRawUcsdNt: [],
-                    rawAsnSignalsRawMeritNt: [],
-                    rawAsnSignalsProcessedBgp: null,
-                    rawAsnSignalsProcessedPingSlash24: null,
-                    rawAsnSignalsProcessedUcsdNt: null,
-                    rawAsnSignalsProcessedMeritNt: null,
-                    rawAsnSignalsLoaded: false,
-                    asnRawSignalsLoadAllButtonClicked: false,
-                    rawSignalsMaxEntitiesHtsError: "",
-                }, () => {
-                    window.scrollTo(0, 0);
-                    this.componentDidMount();
-                });
-                break
-        }
-    }
 
 // Control Panel
     // manage the date selected in the input
@@ -740,7 +578,6 @@ class Entity extends Component {
         const range = dateRangeToSeconds(dateRange, timeRange);
         const { history } = this.props;
         history.push(`/${this.state.entityType}/${this.state.entityCode}?from=${range[0]}&until=${range[1]}`);
-        this.handleStateReset("newTimeFrame", range, null, null);
     }
 // Search bar
     // get data for search results that populate in suggested search list
@@ -771,7 +608,6 @@ class Entity extends Component {
             });
         entity = entity[0];
         history.push(`/${entity.type}/${entity.code}`);
-        this.handleStateReset("newEntity", null, entity.type, entity.code);
     };
     // Reset search bar with search term value when a selection is made, no customizations needed here.
     handleQueryUpdate = (query) => {
@@ -1279,7 +1115,13 @@ class Entity extends Component {
     // Make API call to retrieve topographic data
     getDataTopo(entityType) {
         if (this.state.mounted) {
-            this.props.getTopoAction(entityType);
+            getTopoAction(entityType)
+            .then(data => topojson.feature(data.region.topology, data.region.topology.objects["ne_10m_admin_1.regions.v3.0.0"]))
+            .then(data =>
+            this.setState({
+                    topoData : data
+                },this.getMapScores)
+            )
         }
     }
     // Process Geo data from api, attribute outage scores to a new topoData property where possible, then render Map
@@ -1313,7 +1155,6 @@ class Entity extends Component {
             }
 
             this.setState({topoScores: scores, bounds: outageCoords});
-            console.log(outageCoords);
         }
     }
     // Make API call to retrieve summary data to populate on map
@@ -1333,11 +1174,11 @@ class Entity extends Component {
                     break;
                 case 'region':
                     relatedToEntityType = 'country';
-                    relatedToEntityCode = this.props.entityMetadata[0]["attrs"]["fqid"].split(".")[3];
+                    relatedToEntityCode = this.state.entityMetadata[0]["attrs"]["fqid"].split(".")[3];
                     break;
                 case 'asn':
                     relatedToEntityType = 'asn';
-                    relatedToEntityCode = this.props.entityMetadata[0]["attrs"]["fqid"].split(".")[1];
+                    relatedToEntityCode = this.state.entityMetadata[0]["attrs"]["fqid"].split(".")[1];
                     break;
             }
             // console.log(entityType, relatedToEntityType, relatedToEntityCode);
@@ -1352,7 +1193,6 @@ class Entity extends Component {
                 ? `/region/${entity.properties.id}?from=${window.location.search.split("?")[1].split("&")[0].split("=")[1]}&until=${window.location.search.split("?")[1].split("&")[1].split("=")[1]}`
                 : `/region/${entity.properties.id}`
         );
-        this.handleStateReset("newEntity", null, "region", entity.properties.id);
     }
     // Show/hide modal when button is clicked on either panel
     toggleModal(modalLocation) {
@@ -1408,11 +1248,11 @@ class Entity extends Component {
                     break;
                 case 'region':
                     relatedToEntityType = 'country';
-                    relatedToEntityCode = this.props.entityMetadata[0]["attrs"]["fqid"].split(".")[3];
+                    relatedToEntityCode = this.state.entityMetadata[0]["attrs"]["fqid"].split(".")[3];
                     break;
                 case 'asn':
                     relatedToEntityType = 'asn';
-                    relatedToEntityCode = this.props.entityMetadata[0]["attrs"]["fqid"].split(".")[1];
+                    relatedToEntityCode = this.state.entityMetadata[0]["attrs"]["fqid"].split(".")[1];
                     entityType = 'country';
                     break;
             }
@@ -1438,11 +1278,6 @@ class Entity extends Component {
         }
 
     }
-    // function to manage what happens when a linked entity in the table is clicked
-    handleEntityClick(entityType, entityCode) {
-        this.handleStateReset("newEntity", null, entityType, entityCode);
-    }
-
 
 // RawSignalsModal Windows
     // Make API call that gets raw signals for a group of entities
@@ -2194,7 +2029,6 @@ class Entity extends Component {
                                     handleSelectAndDeselectAllButtons={(event) => this.handleSelectAndDeselectAllButtons(event)}
                                     regionalSignalsTableSummaryDataProcessed={this.state.regionalSignalsTableSummaryDataProcessed}
                                     toggleEntityVisibilityInHtsViz={event => this.toggleEntityVisibilityInHtsViz(event, "region")}
-                                    handleEntityClick={(entityType, entityCode) => this.handleEntityClick(entityType, entityCode)}
                                     handleCheckboxEventLoading={(item) => this.handleCheckboxEventLoading(item)}
                                     asnSignalsTableSummaryDataProcessed={this.state.asnSignalsTableSummaryDataProcessed}
                                     // Regional HTS methods
@@ -2259,7 +2093,6 @@ const mapStateToProps = (state) => {
         datasources: state.iodaApi.datasources,
         suggestedSearchResults: state.iodaApi.entities,
         relatedEntities: state.iodaApi.relatedEntities,
-        entityMetadata: state.iodaApi.entityMetadata,
         relatedToMapSummary: state.iodaApi.relatedToMapSummary,
         relatedToTableSummary: state.iodaApi.relatedToTableSummary,
         topoData: state.iodaApi.topo,
@@ -2291,9 +2124,6 @@ const mapDispatchToProps = (dispatch) => {
         searchEntitiesAction: (searchQuery, limit=15) => {
             searchEntities(dispatch, searchQuery, limit);
         },
-        getEntityMetadataAction: (entityType, entityCode) => {
-            getEntityMetadata(dispatch, entityType, entityCode);
-        },
         searchEventsAction: (from, until, entityType, entityCode, datasource=null, includeAlerts=null, format=null, limit=null, page=null) => {
             searchEvents(dispatch, from, until, entityType, entityCode, datasource, includeAlerts, format, limit, page);
         },
@@ -2306,9 +2136,6 @@ const mapDispatchToProps = (dispatch) => {
 
         searchRelatedToMapSummary: (from, until, entityType, relatedToEntityType, relatedToEntityCode, entityCode, limit, page, includeMetaData) => {
             searchRelatedToMapSummary(dispatch, from, until, entityType, relatedToEntityType, relatedToEntityCode, entityCode, limit, page, includeMetaData);
-        },
-        getTopoAction: (entityType) => {
-            getTopoAction(dispatch, entityType);
         },
         searchRelatedToTableSummary: (from, until, entityType, relatedToEntityType, relatedToEntityCode, entityCode, limit, page, includeMetaData) => {
             searchRelatedToTableSummary(dispatch, from, until, entityType, relatedToEntityType, relatedToEntityCode, entityCode, limit, page, includeMetaData);

--- a/assets/js/Ioda/pages/entity/EntityRelated.js
+++ b/assets/js/Ioda/pages/entity/EntityRelated.js
@@ -106,7 +106,6 @@ class EntityRelated extends Component {
                                 // render function that populates the ui
                                 totalCount={this.props.regionalSignalsTableSummaryDataProcessed.length}
                                 toggleEntityVisibilityInHtsViz={event => this.props.toggleEntityVisibilityInHtsViz(event, "region")}
-                                handleEntityClick={(entityType, entityCode) => this.props.handleEntityClick(entityType, entityCode)}
                                 handleCheckboxEventLoading={(item) => this.props.handleCheckboxEventLoading(item)}
                                 regionalSignalsTableSummaryDataProcessed={this.props.regionalSignalsTableSummaryDataProcessed}
 
@@ -210,7 +209,6 @@ class EntityRelated extends Component {
                                 asnSignalsTableSummaryDataProcessed={this.props.asnSignalsTableSummaryDataProcessed}
                                 // render function that populates the ui
                                 toggleEntityVisibilityInHtsViz={event => this.props.toggleEntityVisibilityInHtsViz(event, "asn")}
-                                handleEntityClick={(entityType, entityCode) => this.props.handleEntityClick(entityType, entityCode)}
                                 handleCheckboxEventLoading={(item) => this.props.handleCheckboxEventLoading(item)}
                                 // data for each horizon time series
                                 rawAsnSignalsProcessedPingSlash24={this.props.rawAsnSignalsProcessedPingSlash24}
@@ -260,7 +258,6 @@ class EntityRelated extends Component {
                                     data={this.props.relatedToTableSummaryProcessed}
                                     totalCount={this.props.relatedToTableSummaryProcessed.length}
                                     entityType={this.props.entityType === "asn" ? "country" : "asn"}
-                                    handleEntityClick={(entityType, entityCode) => this.props.handleEntityClick(entityType, entityCode)}
                                 />
                                 : <Loading/>
                         }


### PR DESCRIPTION
Given an Entity Page is open and trying to open another entity by clicking on the table in a new tab then the current page used to get reloaded with the wrong data. This has been fixed.