### PR TITLE
Size fix twitter widget

### DIFF
--- a/assets/js/Ioda/pages/home/Home.js
+++ b/assets/js/Ioda/pages/home/Home.js
@@ -255,7 +255,7 @@ class Home extends Component {
                             <TwitterTimelineEmbed
                                 sourceType="profile"
                                 screenName="gatech_ioda"
-                                options={{ id: "profile:gatech_ioda", height: '48.3rem'}}
+                                options={{ id: "profile:gatech_ioda", height: '590'}}
                                 lang={localStorage.getItem("lang")}
                             />
                         </div>


### PR DESCRIPTION
Support for rem based height is not working anymore. The value has been replaced with pixel size.