### PR TITLE
Fix: resolving bug where timeseries x-axis is ahead by one hour

### DIFF
--- a/assets/js/Ioda/pages/entity/Entity.js
+++ b/assets/js/Ioda/pages/entity/Entity.js
@@ -944,9 +944,7 @@ class Entity extends Component {
       const seriesDataValues = [];
       const seriesDataValuesNormalized = [];
       datasource.values.forEach((value, index) => {
-        const x = toDateTime(
-          datasource.from + datasource.step * index
-        ).getTime();
+        const x = 1000 * (datasource.from + datasource.step * index);
         const normalY = normalize(value, seriesMax);
         const y = this.state.tsDataNormalized ? normalY : value;
 
@@ -1196,7 +1194,6 @@ class Entity extends Component {
         enabled: true,
         time: {
           useUTC: true,
-          timezoneOffset: new Date().getTimezoneOffset(),
         },
         margin: 10,
         maskFill: "rgba(50, 184, 237, 0.3)",
@@ -1225,7 +1222,6 @@ class Entity extends Component {
       },
       time: {
         useUTC: true,
-        timezoneOffset: new Date().getTimezoneOffset(),
       },
       plotOptions: {
         spline: {


### PR DESCRIPTION
Aniket discovered that times between daylight savings in prod are currently one hour ahead of the actual UTC time (when visualized on the chart). After investigation, the issue is likely due to converting a UTC time to ET, then back to UTC. 

![Screenshot 2023-04-22 at 7 23 01 PM](https://user-images.githubusercontent.com/8345645/235717757-5e6f88c7-cffd-422c-ae43-8aa2ec9d4956.png)

This fix uses the raw UTC timestamp from the API instead of performing any intermediate conversions. This fix was validated against GTR data and members of OONI (for international correctness).