### PR TITLE
Continued adjustments to timezones

### DIFF
--- a/assets/js/Ioda/components/controlPanel/ControlPanel.js
+++ b/assets/js/Ioda/components/controlPanel/ControlPanel.js
@@ -29,7 +29,10 @@ import {
     getUTCTimeStringFromDate, secondaryColor, secondaryColorDark, secondaryColorLight
 } from "../../utils";
 import PreloadImage from "react-preload-image";
+
 import dayjs from 'dayjs';
+const utc = require("dayjs/plugin/utc");
+dayjs.extend(utc);
 
 class ControlPanel extends Component {
     constructor(props) {
@@ -124,14 +127,13 @@ class ControlPanel extends Component {
         }
     }
 
-    // set text that renders in bottom right hand corner depicting the start and end date of the currently viewable range
+    // set text in top left input control box
     setDateInLegend(from, until) {
-        const dateFormat = "MMMM D, YYYY HH:mma UTC"
-        const timezoneOffset = new Date().getTimezoneOffset() * 60
-        const fromMilliseconds = (parseInt(from) + timezoneOffset) * 1000
-        const untilMilliseconds = (parseInt(until) + timezoneOffset) * 1000
-        const startDate = dayjs(fromMilliseconds).format(dateFormat)
-        const endDate = dayjs(untilMilliseconds).format(dateFormat)
+        const dateFormat = "MMMM D, YYYY h:mma UTC"
+        const fromMilliseconds = parseInt(from) * 1000
+        const untilMilliseconds = parseInt(until) * 1000
+        const startDate = dayjs.utc(fromMilliseconds).format(dateFormat)
+        const endDate = dayjs.utc(untilMilliseconds).format(dateFormat)
         return [ startDate, endDate ];
     }
 

--- a/assets/js/Ioda/components/timeStamp/TimeStamp.js
+++ b/assets/js/Ioda/components/timeStamp/TimeStamp.js
@@ -1,6 +1,9 @@
 import React, { Component } from 'react';
-import {convertSecondsToDateValues} from "../../utils";
 import T from "i18n-react";
+
+import dayjs from 'dayjs';
+const utc = require("dayjs/plugin/utc");
+dayjs.extend(utc);
 
 
 class TimeStamp extends Component {
@@ -49,7 +52,11 @@ class TimeStamp extends Component {
     }
 
     render() {
-        const timestamp = `${this.props.from.month} ${this.props.from.day}, ${this.props.from.year} ${this.props.from.hours}:${this.props.from.minutes}${this.props.from.meridian} UTC — ${this.props.until.month} ${this.props.until.day}, ${this.props.until.year} ${this.props.until.hours}:${this.props.until.minutes}${this.props.until.meridian} UTC`;
+        const format = "MMMM D, YYYY h:mma UTC"
+        const fromDate = dayjs.utc(this.props.from * 1000).format(format)
+        const untilDate = dayjs.utc(this.props.until * 1000).format(format)
+        const timestamp = `${fromDate} - ${untilDate}`
+        
         const fade = this.state.fade;
         const hoverTitle = T.translate("timestamp.hoverTitle");
         const copyToClipboardMessage = T.translate("timestamp.copyToClipboardMessage");

--- a/assets/js/Ioda/pages/dashboard/DashboardTab.js
+++ b/assets/js/Ioda/pages/dashboard/DashboardTab.js
@@ -68,9 +68,6 @@ class DashboardTab extends Component {
         const tooltipDashboardHeadingTitle = T.translate("tooltip.dashboardHeading.title");
         const tooltipDashboardHeadingText = T.translate("tooltip.dashboardHeading.text");
 
-        const fromUTCSeconds = this.props.from + (new Date().getTimezoneOffset() * 60)
-        const untilUTCSeconds = this.props.until + (new Date().getTimezoneOffset() * 60)
-
         return(
             <div className="tab">
                 <Style>{`
@@ -142,8 +139,7 @@ class DashboardTab extends Component {
                                                         : null
                                                 }
                                             </div>
-                                            <TimeStamp from={convertSecondsToDateValues(fromUTCSeconds)}
-                                                       until={convertSecondsToDateValues(untilUTCSeconds)} />
+                                            <TimeStamp from={this.props.from} until={this.props.until} />
                                         </div>
                                         <div className="col-1-of-3">
                                             <div className="tab__table">

--- a/assets/js/Ioda/pages/entity/Entity.js
+++ b/assets/js/Ioda/pages/entity/Entity.js
@@ -1551,28 +1551,29 @@ class Entity extends Component {
     // Get the relevant values to populate table with
     let eventData = [];
     this.state.eventDataRaw.map((event) => {
+      console.log(event.start);
+      const fromDate = dayjs.utc(event.start * 1000);
+      const untilDate = dayjs.utc((event.start + event.duration) * 1000);
       const eventItem = {
         age: sd.stringify((event.start + event.duration) / 1000, "s"),
         from: {
-          month: convertSecondsToDateValues(event.start).month,
-          day: convertSecondsToDateValues(event.start).day,
-          year: convertSecondsToDateValues(event.start).year,
-          hours: convertSecondsToDateValues(event.start).hours,
-          minutes: convertSecondsToDateValues(event.start).minutes,
-          meridian: convertSecondsToDateValues(event.start).meridian,
+          month: fromDate.format("MMMM"),
+          day: fromDate.format("D"),
+          year: fromDate.format("YYYY"),
+          hours: fromDate.format("hh"),
+          minutes: fromDate.format("mm"),
+          meridian: fromDate.format("a"),
         },
-        fromDate: new Date(event.start * 1000),
+        fromDate: fromDate.toDate(),
         until: {
-          month: convertSecondsToDateValues(event.start + event.duration).month,
-          day: convertSecondsToDateValues(event.start + event.duration).day,
-          year: convertSecondsToDateValues(event.start + event.duration).year,
-          hours: convertSecondsToDateValues(event.start + event.duration).hours,
-          minutes: convertSecondsToDateValues(event.start + event.duration)
-            .minutes,
-          meridian: convertSecondsToDateValues(event.start + event.duration)
-            .meridian,
+          month: untilDate.format("MMMM"),
+          day: untilDate.format("D"),
+          year: untilDate.format("YYYY"),
+          hours: untilDate.format("hh"),
+          minutes: untilDate.format("mm"),
+          meridian: untilDate.format("a"),
         },
-        untilDate: new Date(event.start * 1000 + event.duration * 1000),
+        untilDate: untilDate.toDate(),
         duration: sd.stringify(event.duration, "s"),
         score: humanizeNumber(event.score),
       };

--- a/assets/js/Ioda/pages/entity/Entity.js
+++ b/assets/js/Ioda/pages/entity/Entity.js
@@ -1393,8 +1393,8 @@ class Entity extends Component {
         this.state.eventDataRaw.forEach((event) => {
           alertBands.push({
             color: "rgba(250, 62, 72, 0.2)",
-            from: toDateTime(event.start).getTime(),
-            to: toDateTime(event.start + event.duration).getTime(),
+            from: event.start * 1000,
+            to: (event.start + event.duration) * 1000,
           });
         });
       }

--- a/assets/js/Ioda/pages/entity/Entity.js
+++ b/assets/js/Ioda/pages/entity/Entity.js
@@ -110,9 +110,12 @@ import Tabs from "../../components/tabs/Tabs";
 // Chart libraries
 import Highcharts from "highcharts/highstock";
 import HighchartsReact from "highcharts-react-official";
-import dayjs from "dayjs";
 require("highcharts/modules/exporting")(Highcharts);
 require("highcharts/modules/offline-exporting")(Highcharts);
+
+import dayjs from "dayjs";
+const utc = require("dayjs/plugin/utc");
+dayjs.extend(utc);
 
 const CUSTOM_FONT_FAMILY = "Lato-Regular, sans-serif";
 const dataSource = ["bgp", "ping-slash24", "merit-nt", "gtr.WEB_SEARCH"];
@@ -127,9 +130,9 @@ const getRangeDatesFromUrl = () => {
   const urlUntilDate = urlParams.get("until");
 
   const defaultFromDateSeconds = Math.floor(
-    (new Date().getTime() - 24 * 60 * 60 * 1000) / 1000
+    dayjs.utc().subtract(24, "hour").valueOf() / 1000
   );
-  const defaultUntilDateSeconds = Math.floor(new Date().getTime() / 1000);
+  const defaultUntilDateSeconds = Math.floor(dayjs.utc().valueOf() / 1000);
 
   return {
     fromDate: parseInt(urlFromDate) || defaultFromDateSeconds,
@@ -1075,14 +1078,8 @@ class Entity extends Component {
       this.state.entityName
     }`;
     const { fromDate, untilDate } = getRangeDatesFromUrl();
-    const fromDayjs = dayjs(fromDate * 1000).add(
-      new Date().getTimezoneOffset(),
-      "minutes"
-    );
-    const untilDayjs = dayjs(untilDate * 1000).add(
-      new Date().getTimezoneOffset(),
-      "minutes"
-    );
+    const fromDayjs = dayjs.utc(fromDate * 1000);
+    const untilDayjs = dayjs.utc(untilDate * 1000);
 
     const formatExpanded = "MMMM D, YYYY h:mma";
     const formatCompact = "YY-MM-DD-HH-mm";
@@ -1335,18 +1332,8 @@ class Entity extends Component {
       series: chartSignals,
     };
 
-    // Set navigator time bounds. If we're rendering the chart for the first
-    // time (i.e., when the xyChartOptions is still null), we need to add a
-    // timezone offset to the bounds
-    let timezoneOffsetSeconds = 0;
-    if (!this.state.xyChartOptions) {
-      timezoneOffsetSeconds = new Date().getTimezoneOffset() * 60;
-    }
-
-    const navigatorLowerBound =
-      (this.state.tsDataLegendRangeFrom + timezoneOffsetSeconds) * 1000;
-    const navigatorUpperBound =
-      (this.state.tsDataLegendRangeUntil + timezoneOffsetSeconds) * 1000;
+    const navigatorLowerBound = this.state.tsDataLegendRangeFrom * 1000;
+    const navigatorUpperBound = this.state.tsDataLegendRangeUntil * 1000;
 
     // Rerender chart and set navigator bounds
     this.setState({ xyChartOptions: chartOptions }, () => {
@@ -1356,9 +1343,9 @@ class Entity extends Component {
   }
 
   setDefaultNavigatorTimeRange() {
-    const timezoneOffsetSeconds = new Date().getTimezoneOffset() * 60;
-    const navigatorLowerBound = (fromDate + timezoneOffsetSeconds) * 1000;
-    const navigatorUpperBound = (untilDate + timezoneOffsetSeconds) * 1000;
+    const { fromDate, untilDate } = getRangeDatesFromUrl();
+    const navigatorLowerBound = fromDate * 1000;
+    const navigatorUpperBound = untilDate * 1000;
 
     this.setChartNavigatorTimeRange(navigatorLowerBound, navigatorUpperBound);
   }
@@ -2897,12 +2884,8 @@ class Entity extends Component {
                 {this.state.xyChartOptions ? this.renderXyChart() : <Loading />}
                 <div className="overview__timestamp">
                   <TimeStamp
-                    from={convertSecondsToDateValues(
-                      this.state.tsDataLegendRangeFrom
-                    )}
-                    until={convertSecondsToDateValues(
-                      this.state.tsDataLegendRangeUntil
-                    )}
+                    from={this.state.tsDataLegendRangeFrom}
+                    until={this.state.tsDataLegendRangeUntil}
                   />
                 </div>
               </div>

--- a/assets/js/Ioda/pages/entity/Entity.js
+++ b/assets/js/Ioda/pages/entity/Entity.js
@@ -1595,18 +1595,19 @@ class Entity extends Component {
     // Get the relevant values to populate table with
     let alertData = [];
     this.state.alertDataRaw.map((alert) => {
+      const alertDate = dayjs.utc(alert.time * 1000);
       const alertItem = {
         entityName: alert.entity.name,
         level: alert.level,
         date: {
-          month: convertSecondsToDateValues(alert.time).month,
-          day: convertSecondsToDateValues(alert.time).day,
-          year: convertSecondsToDateValues(alert.time).year,
-          hours: convertSecondsToDateValues(alert.time).hours,
-          minutes: convertSecondsToDateValues(alert.time).minutes,
-          meridian: convertSecondsToDateValues(alert.time).meridian,
+          month: alertDate.format("MMMM"),
+          day: alertDate.format("D"),
+          year: alertDate.format("YYYY"),
+          hours: alertDate.format("hh"),
+          minutes: alertDate.format("mm"),
+          meridian: alertDate.format("a"),
         },
-        dateStamp: new Date(alert.time * 1000),
+        dateStamp: alertDate.toDate(),
         dataSource: alert.datasource,
         actualValue: alert.value,
         baselineValue: alert.historyValue,


### PR DESCRIPTION
Zach discovered a bug with the placement of alert bands on the time series chart. To fix this, this change removes all timezone offset calculations in the navigator, timestamps, alerts table, and events table. We now rely solely on the raw timestamp values from the API, combined with Dayjs UTC. This change marks a continued effort to consolidate timestamp conversion logic.