### PR TITLE
fix/stacked-horizon-axis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ npm-debug.log
 yarn-error.log
 ###< symfony/webpack-encore-pack ###
 .DS_Store
+
+.php-version

--- a/assets/js/Ioda/utils/index.js
+++ b/assets/js/Ioda/utils/index.js
@@ -263,7 +263,7 @@ export function convertTsDataForHtsViz(tsData) {
                 entityCode: signal.entityCode,
                 entityName: signal.entityName,
                 datasource: signal.datasource,
-                ts: secondsToUTC(signal.from * 1000 + signal.step * 1000 * index).toDate(),
+                ts: secondsToUTC(signal.from + signal.step * index).toDate(),
                 val: value
             };
             const max = Math.max.apply(null, values);


### PR DESCRIPTION
Resolve bug where stacked horizon chart mistakenly uses millisecond values for a seconds calculation, resulting in incorrect date values. Also adds `.php-version` file to gitignore.