### PR TITLE
Fix page reload issue

### DIFF
--- a/assets/js/Ioda/pages/entity/Entity.js
+++ b/assets/js/Ioda/pages/entity/Entity.js
@@ -36,7 +36,7 @@
  */
 
 // React Imports
-import React, { Component, useEffect } from "react";
+import React, { Component, useEffect, useRef } from "react";
 import { connect } from "react-redux";
 import { useNavigate, useParams } from "react-router-dom";
 // Internationalization
@@ -3496,19 +3496,18 @@ const mapDispatchToProps = (dispatch) => {
 
 const EntityFn = (props) => {
   const navigate = useNavigate();
+  // using useRef to avoid re-rendering between renders
+  const previousFullPath = useRef(window.location.href);
   const { entityCode, entityType } = useParams();
 
-  const handleLocationChange = () => {
-    window.location.reload();
-  };
-
+  // Reload page if the URL changes.
   useEffect(() => {
-    window.addEventListener("popstate", handleLocationChange);
-
-    return () => {
-      window.removeEventListener("popstate", handleLocationChange);
-    };
-  }, []);
+    if (previousFullPath.current !== window.location.href) {
+      previousFullPath.current = window.location.href;
+      
+      window.location.reload();
+    }
+  }, [window.location.href]);
 
   return (
     <Entity


### PR DESCRIPTION
## Description of the Problem

Previously, it was possible to listen to changes in the browser url using

```javascript
this.props.history.listen((location, action) => {
  window.location.reload();
});
```

After migrating to v6 of react router DOM, `history.listen` was not usable since it had been removed. In replacement, the following approach was taken

```javascript
  const handleLocationChange = () => {
    window.location.reload();
  };

  useEffect(() => {
    window.addEventListener("popstate", handleLocationChange);

    return () => {
      window.removeEventListener("popstate", handleLocationChange);
    };
  }, []);
```

The `popstate` event did not however capture the full scope of the kind of url changes that should trigger a page reload.

## Fix
Use `window.location.href` to determine when to trigger a reload. This change ensures that any change in the url (path name, query params and hash) will cause a reload.

Closes https://github.com/InetIntel/ioda-ui/issues/146